### PR TITLE
Remove preentationWidth from Partners page GraphQL query

### DIFF
--- a/src/templates/about-page-partners.js
+++ b/src/templates/about-page-partners.js
@@ -93,7 +93,7 @@ export const pageQuery = graphql`
             publicURL
             extension
             childImageSharp {
-              fluid(maxWidth: 405, quality: 100) {
+              fluid(maxWidth: 405, quality: 80) {
                 ...GatsbyImageSharpFluid
               }
             }

--- a/src/templates/about-page-partners.js
+++ b/src/templates/about-page-partners.js
@@ -95,7 +95,6 @@ export const pageQuery = graphql`
             childImageSharp {
               fluid(maxWidth: 405, quality: 100) {
                 ...GatsbyImageSharpFluid
-                presentationWidth
               }
             }
           }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Modify graph QL query in Partners page to comply with updated version of NonStretchedImage.
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Only logos in svg format was rendered in the About/Partners page
### Checklist - Required Tests:

* [ ] Have you added CMS configuration for Netlify CMS in `static/admin/config.yml`? This only applies when creating new templates and pages. 
* [x] Is `gatsby clean && gatsby build && gatsby develop -H 0.0.0.0` running without any fails?
* [ ] Has your pull request been tested with: Google Lighthouse? https://developers.google.com/web/tools/lighthouse (Not required, but recommended)
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### This MR has been tested in following browsers:

* [x] Chrome
* [x] Firefox
* [ ] Safari
* [ ] iOS Safari
