### PR TITLE
Crop livestream preview image

### DIFF
--- a/src/components/Livestream/Livestream.js
+++ b/src/components/Livestream/Livestream.js
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 import styles from './Livestream.module.scss';
 // import { ReactComponent as LivestreamIcon } from '../../../images/sealabIcons/livestream_play.svg';
 import LivestreamPlayIcon from '../../img/icon-livestream-play.inline.svg';
-import PreviewImage from '../../img/seagulls_nest.jpg';
+import PreviewImage from '../../img/seagull_south_east_crop.jpg';
 
 const Livestream = () => {
   const [playerKey, setPlayerKey] = useState(null);


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
Replace current image with a cropped version. In the cropped version, the seagull is not centered preventing it from being covered by the play icon.

### Checklist - Required Tests:

* [ ] Have you added CMS configuration for Netlify CMS in `static/admin/config.yml`? This only applies when creating new templates and pages. 
* [x] Is `gatsby clean && gatsby build && gatsby develop -H 0.0.0.0` running without any fails?
* [ ] Has your pull request been tested with: Google Lighthouse? https://developers.google.com/web/tools/lighthouse (Not required, but recommended)
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### This MR has been tested in following browsers:

* [x] Chrome
* [ ] Firefox
* [ ] Safari
* [ ] iOS Safari
