### PR TITLE
Updated site to use new state variables friendlyTitleName_en and frie…

### DIFF
--- a/src/components/Schedule/CurrentTimeline/CurrentTimeline.js
+++ b/src/components/Schedule/CurrentTimeline/CurrentTimeline.js
@@ -54,8 +54,8 @@ const CurrentTimeline = ({ heading, event }) => {
 
   if (!heading || !event) return <></>;
   const {
-    friendlyName,
-    friendlyCameraName,
+    friendlyTitleName_en: friendlyTitleName,
+    friendlyCameraName_en: friendlyCameraName,
     start_time: startTime,
     stop_time: endTime,
   } = event;
@@ -74,7 +74,7 @@ const CurrentTimeline = ({ heading, event }) => {
         <EventText
           startTime={friendlyStartTime}
           endTime={friendlyEndTime}
-          heading={friendlyName}
+          heading={friendlyTitleName}
           camName={friendlyCameraName}
           isActive
         />

--- a/src/components/Schedule/NextEvent/NextEvent.js
+++ b/src/components/Schedule/NextEvent/NextEvent.js
@@ -4,10 +4,10 @@ import TimelineText from '../TimelineText';
 import { getDigitalTime } from '../../../utils/date';
 
 const NextEvent = ({ heading, event }) => {
-  if (!heading || !event || !event.friendlyName) return <></>;
+  if (!heading || !event || !event.friendlyTitleName_en) return <></>;
   const {
-    friendlyName,
-    friendlyCameraName,
+    friendlyTitleName_en: friendlyTitleName,
+    friendlyCameraName_en: friendlyCameraName,
     start_time: startTime,
     stop_time: endTime,
   } = event;
@@ -21,7 +21,7 @@ const NextEvent = ({ heading, event }) => {
         <TimelineText
           startTime={friendlyStartTime}
           endTime={friendlyEndTime}
-          heading={friendlyName}
+          heading={friendlyTitleName}
           camName={friendlyCameraName}
         />
       </div>

--- a/src/components/Schedule/Program/Program.js
+++ b/src/components/Schedule/Program/Program.js
@@ -19,8 +19,8 @@ const Program = ({ className, heading, events }) => {
             key={gen.next().value}
             startTime={eventItem.start_time}
             endTime={eventItem.stop_time}
-            friendlyName={eventItem.friendlyName}
-            cam={eventItem.friendlyCameraName}
+            friendlyTitleName={eventItem.friendlyTitleName_en}
+            cam={eventItem.friendlyCameraName_en}
           />
         );
       })}
@@ -28,7 +28,7 @@ const Program = ({ className, heading, events }) => {
   );
 };
 
-const EventItem = ({ startTime, endTime, friendlyName, cam }) => {
+const EventItem = ({ startTime, endTime, friendlyTitleName, cam }) => {
   const friendlyStartTime = getDigitalTime(startTime);
   const friendlyEndTime = getDigitalTime(endTime);
 
@@ -40,7 +40,7 @@ const EventItem = ({ startTime, endTime, friendlyName, cam }) => {
       <p
         className={styles.event__time}
       >{`${friendlyStartTime} - ${friendlyEndTime}`}</p>
-      <h4 className={styles.event__heading}>{friendlyName}</h4>
+      <h4 className={styles.event__heading}>{friendlyTitleName}</h4>
       <div className={styles.event__duration}>
         <ClockIcon />
         <p>{duration}</p>


### PR DESCRIPTION
…ndlyCameraName_en instead of friendlyName and friendlyCameraName.

<!--- Provide a general summary of your changes in the Title above -->

## Description
Updated site to use new state variables friendlyTitleName_en and friendlyCameraName_en instead of friendlyName and friendlyCameraName.

## Related Issue in Jira
https://sealab.atlassian.net/browse/KR-864?atlOrigin=eyJpIjoiMzIyMDY1MzJjNDU2NDgyM2EwYjgzMjQxM2YyNGU0Y2MiLCJwIjoiaiJ9

## Motivation and Context
New state variables for the livestream schedule have been made that append a language tag (_en, _no) to the existing variable names. The site should use the new ones so that the old ones can be deleted.

### Checklist - Required Tests:

* [x] Is `gatsby clean && gatsby build && gatsby develop -H 0.0.0.0` running without any fails?

### This MR has been tested in following browsers:

* [x] Chrome
* [x] Firefox
* [ ] Safari
* [ ] iOS Safari
